### PR TITLE
fix decoding of hash for cipher

### DIFF
--- a/test/QVaultCrypto.test.js
+++ b/test/QVaultCrypto.test.js
@@ -85,7 +85,8 @@ it('cipher and decipher', async () => {
       }
     }
   };
-  const hashedCharKey = "fhdsbf7aisduifgsdifuagsdfgsdjhfgsdjhlfashdfg";
+  const charKey = await GenerateCharKey();
+  const hashedCharKey = await HashCharKey(charKey);
   const qrKey = "fhdsbf7aisduifgsjifuagsdfgsdjhfgsdjhlfashdfg";
   const ciphered = CipherSecrets(hashedCharKey, mySecrets);
   const deciphered = DecipherSecrets(hashedCharKey, ciphered);


### PR DESCRIPTION
The key used for ciphering and deciphering should be decoded as base64 not utf-8. That will give the key an exact 32 byte size.
#311 