### PR TITLE
create and modify preferences.json file for online preference

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -19,6 +19,7 @@ import TitleBar from './components/TitleBar.vue';
 import {heightMac, heightWin} from './consts/titleBar';
 import LockScreen from './components/LockScreen.vue';
 import { store } from './store/store';
+import {preferenceFileExists, createPreferenceFile} from './lib/appPreferences';
 
 export const router = new VueRouter({routes});
 
@@ -53,6 +54,9 @@ export default {
     window.nodeAPI.electron.ipcRenderer.on('updateReady', () => {
       this.updateReady = true;
     });
+    if (!preferenceFileExists()){
+      createPreferenceFile();
+    }
   },
   router
 };

--- a/src/components/OnlineSwitch.vue
+++ b/src/components/OnlineSwitch.vue
@@ -13,6 +13,7 @@
 import ToggleSwitch from './ToggleSwitch.vue';
 import { internetAvailable } from '../lib/cloudClient';
 import sleep from '../lib/sleep';
+import { getPreferenceFromFile } from '../lib/appPreferences';
 
 export default {
   components:{
@@ -56,7 +57,7 @@ export default {
   },
   async beforeCreate(){
     // show we are offine if we have no connection
-    if(!await internetAvailable()){
+    if(!await internetAvailable() || !getPreferenceFromFile('onlineMode')){
       this.$store.commit('setAppOnline', false);
     }
   }

--- a/src/consts/defaultPreferences.json
+++ b/src/consts/defaultPreferences.json
@@ -1,0 +1,3 @@
+{
+  "onlineMode": true
+} 

--- a/src/lib/appPreferences.js
+++ b/src/lib/appPreferences.js
@@ -1,0 +1,34 @@
+export function getPreferenceFromFile(key){
+  if (!preferenceFileExists()){
+    return;
+  }
+  const preferences = getPreferences(getPreferenceFilePath());
+  return preferences[key]; 
+}
+
+export function writeToPreferenceFile(key, value){
+  const path = getPreferenceFilePath();
+  const preferences = getPreferences(path);
+  preferences[key] = value;
+  window.nodeAPI.fs.writeFileSync(path, JSON.stringify(preferences));
+}
+
+export function preferenceFileExists () {
+  return window.nodeAPI.fs.existsSync(getPreferenceFilePath());
+}
+
+export function createPreferenceFile () {
+  const defaultPreferences = require('../consts/defaultPreferences.json');
+  const path = getPreferenceFilePath();
+  window.nodeAPI.fs.writeFileSync(path, JSON.stringify(defaultPreferences));
+}
+
+function getPreferences(path){
+  const file = window.nodeAPI.fs.readFileSync(path,'utf-8');
+  return JSON.parse(file);
+}
+
+function getPreferenceFilePath(){
+  const configDir = (window.nodeAPI.electron.app || window.nodeAPI.electron.remote.app).getPath('userData');
+  return `${configDir}/preferences.json`;
+}

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -1,5 +1,6 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
+import {writeToPreferenceFile} from '../lib/appPreferences';
 
 Vue.use(Vuex);
 
@@ -17,8 +18,10 @@ export const store = new Vuex.Store({
       state.isAppOnline = isOnline;
       if (isOnline){
         window.nodeAPI.electron.ipcRenderer.send('setOnline');
+        writeToPreferenceFile('onlineMode',true);
       } else{
         window.nodeAPI.electron.ipcRenderer.send('setOffline');
+        writeToPreferenceFile('onlineMode',false);
       }
     },
     pushConflict(state, newConflict){


### PR DESCRIPTION
Hi,

This is addressing issue #353. I am resubmitting the PR which I closed (#384 ) due to some poor git practices on my part. 

The comments in the failed PR were addressed. The description is the same:

   1. Added a default preferences file, to use for creating the file.
   2. Create the preference.json file (if it does not exist) when the app starts up. I added it to App.vue because it was the highest level to do this, without putting it in the electron setup.
  3. The file gets read (if it exists) when the OnlineSwitch is first rendered.
   4. The file is modified when the setOnlineMode reducer gets called.

I tried to write the code so that if the file is not found, it would not break anything. The application logic will still set the onlineMode to true by default without any file.

Cheers,
Lena

